### PR TITLE
Add --doconly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Into:
     Options:
       -o --output=DIR           The output directory
       -l --language=LANG        Forces using language for all files
+      -d --doconly               Omits code sections from the output.
 
 
 ## Platform support

--- a/bin/sug.js
+++ b/bin/sug.js
@@ -31,6 +31,7 @@ var doc = "sug --- Sucks Markdown outta your source files.\n"
         + "Options:\n"
         + "  -o --output=DIR            The output directory.\n"
         + "  -l --language=LANG         Forces use of language for all files.\n"
+        + "  -d --doconly               Omits code sections from the output.\n"
         + "\n"
 
 var fs     = require('fs')
@@ -49,7 +50,8 @@ var args  = docopt(doc, { version: pkg.version })
 
   args.languages?  listLanguages()
 : args.convert?    convertFiles(args['<files>'], args['--output']
-                                               , args['--language'])
+                                               , args['--language']
+                                               , args['--doconly'])
 : /* otherwise */  printHelp()
 
 
@@ -63,14 +65,14 @@ function listLanguages() {
                 return ' - ' + a.name + spacing + a.friendlyName }).join('\n'))}
 
 
-function convertFiles(xs, output, language) {
+function convertFiles(xs, output, language, doconly) {
   output = output || '.'
 
   xs.forEach(function(x) {
     var filename = path.basename(x, path.extname(x))
     var outfile  = path.join(output, filename + '.md')
     try {
-      fs.writeFileSync(outfile, cli.convert(x, language), 'utf-8')
+      fs.writeFileSync(outfile, cli.convert(x, language, doconly), 'utf-8')
       console.log('Successfully converted: ' + x) }
     catch (e) {
       if (e.name != 'ConversionError') throw e

--- a/cli.js
+++ b/cli.js
@@ -44,13 +44,16 @@ function languageFromName(name) {
 function raise(error) {
   throw error }
 
-function convert(filename, languageName) {
+function convert(filename, languageName, doconly) {
   var language = languageName?    languageFromName(languageName)
                : /* otherwise */  languageForFile(filename)
 
   if (!language)  throw ConversionError("Does not know how to handle: " + filename)
 
-  return sug.render(sug.parse(read(filename), language)) }
+  var filterTokens = doconly?         _.filter(function(a) { return a.type != 'Code' })
+                   : /* otherwise */  _.id
+
+  return sug.render(filterTokens(sug.parse(read(filename), language))) }
 
 module.exports = { convert: convert
                  , languageFromName: languageFromName


### PR DESCRIPTION
Omits `Code` tokens, leaving just the documentation.